### PR TITLE
feat(project): Add issue templates for flaws and proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/conceptual-flaw-report.md
+++ b/.github/ISSUE_TEMPLATE/conceptual-flaw-report.md
@@ -1,0 +1,24 @@
+---
+name: "Conceptual Flaw Report"
+about: "Report a loophole, contradiction, or potential for abuse in a document."
+title: "[Flaw]: A brief, descriptive title of the issue"
+labels: ["bug", "red team"]
+---
+
+<!-- Thank you for helping to strengthen the Dominion Covenant. Please provide the following details to ensure your report is clear and actionable. -->
+
+### Document and Section
+<!-- Please specify the exact document and section/article where the flaw exists. -->
+*   **Document:**
+*   **Article/Section:**
+
+### Description of the Flaw
+<!-- Clearly and concisely describe the conceptual flaw, loophole, or contradiction. -->
+
+
+### Adversarial Scenario
+<!-- How could this flaw be exploited? Describe a realistic scenario where it could lead to an unjust outcome or be abused by the state. -->
+
+
+### Proposed Fortification
+<!-- How would you patch this vulnerability? Please provide your suggested change to the text. If it is a significant change, you can provide a general outline of the solution. -->

--- a/.github/ISSUE_TEMPLATE/new-content-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-content-proposal.md
@@ -1,0 +1,22 @@
+---
+name: "New Content Proposal"
+about: "Propose new content, such as a new article, section, or piece of model legislation."
+title: "[Proposal]: A brief title for the new content"
+labels: ["enhancement"]
+---
+
+<!-- Thank you for contributing your ideas. To make your proposal as clear as possible, please provide the following information. -->
+
+### Summary of Proposal
+<!-- What new content are you proposing? Be as specific as possible (e.g., "Add a new Part to the Criminal Law Act for Burglary," "Create a new Memorandum on Economic Policy"). -->
+
+
+### Rationale
+<!-- Why is this addition necessary? Does it fill a logical gap in the framework? Does it implement a mandate from one of the core charters? -->
+
+
+### Draft Text
+<!-- Please provide the full draft text for your proposed addition below. -->
+
+```markdown
+<!-- PASTE YOUR DRAFT MARKDOWN HERE -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: "Question or General Discussion"
+about: "For general questions or high-level discussions, please use our Discussions tab."
+---
+
+Thank you for your interest in the Dominion Covenant.
+
+The GitHub Issues tracker is reserved for **actionable bug reports and specific content proposals.**
+
+For general questions, high-level feedback, or philosophical discussions, please use the **[Discussions Tab](https://github.com/YourUsername/The-Dominion-Covenant/discussions)**, which is the designated forum for these conversations.
+
+This helps us keep the issue tracker focused and organized.


### PR DESCRIPTION
This PR establishes a formal set of Issue Templates to guide contributor feedback.

### Key Additions:
*   **Conceptual Flaw Report:** A template for reporting specific loopholes, contradictions, or potential abuses in the documents.
*   **New Content Proposal:** A template for proposing new sections, articles, or model legislation.
*   **Question/Discussion Redirect:** A template that directs general questions to the GitHub Discussions tab to keep the Issues tracker focused on actionable items.

This will help standardize incoming feedback and make it easier to manage the project.