### PR TITLE
Docs: Add Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Thank you for your contribution to the Dominion Covenant.
+To ensure your work is reviewed efficiently, please complete the following sections.
+-->
+
+### Related Issue
+<!--
+A Pull Request for any substantive change **MUST** be linked to an approved GitHub Issue.
+Please link to the issue that this PR addresses.
+-->
+
+Fixes # (issue)
+
+### Description of Changes
+<!--
+Please provide a clear and concise summary of the changes you have made. What is the purpose of this PR? What problem does it solve or what feature does it add?
+-->
+
+
+### Type of Change
+<!--
+Please check the box that best describes the nature of your change.
+-->
+
+- [ ] `fix`: A correction of a loophole, typo, or error.
+- [ ] `feat`: A new feature or addition (e.g., adding a new section or article).
+- [ ] `docs`: Changes to documentation files (e.g., README, style guides).
+- [ ] `style`: Formatting changes that do not affect the meaning of the text.
+- [ ] `refactor`: Rewriting or restructuring text without changing its functional meaning.
+- [ ] `chore`: Changes to repository maintenance or configuration.
+
+### Contributor Checklist
+<!--
+Please review this checklist and mark each box with an 'x' to confirm you have followed the project's standards.
+-->
+
+- [ ] I have read and agree to the terms of the project's **[Contribution Policy](/CONTRIBUTING.md)**.
+- [ ] My commit messages follow the **[Conventional Commits standard](/CONTRIBUTING.md)**.
+- [ ] My changes adhere to the project's **[Markdown Style Guide](/STYLE_GUIDE.md)**.
+- [ ] I have thoroughly proofread my own changes for any typos or grammatical errors.
+- [ ] For any substantive change, this PR is linked to an approved **GitHub Issue**.


### PR DESCRIPTION
This PR adds a `PULL_REQUEST_TEMPLATE.md` to the `.github` directory.

This template is designed to standardize contributions by requiring contributors to:
- Link their PR to an approved GitHub Issue for all substantive changes.
- Clearly describe the purpose and nature of their changes.
- Complete a checklist to confirm they have followed all project guidelines, including the Contribution Policy, commit message standards, and style guide.

This will improve the quality and consistency of all future pull requests.