### PR TITLE
docs(project): Add stewardship dedication to project files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,16 +1,28 @@
 # License and Copyright Information
 
-## Copyright
+### Dedication
+
+This work is dedicated to the glory of God. The human author acts as a humble steward, holding the legal copyright in trust for the sole purpose of preserving the integrity of the work and ensuring it remains true to its foundational principles. All credit for any wisdom, coherence, or truth found herein belongs to Him alone.
+
+*Soli Deo Gloria*
+
+---
+
+### Copyright
 
 Copyright © 2025 Jadon.M.Banninga. All Rights Reserved.
 
-## Licensing Terms
+---
+
+### Licensing Terms
 
 The Dominion Covenant project is a proprietary work. The author retains all rights to the work under copyright law.
 
 No part of this work may be reproduced, distributed, or transmitted in any form or by any means, including photocopying, recording, or other electronic or mechanical methods, without the prior written permission of the author, except in the case of brief quotations embodied in critical reviews and certain other noncommercial uses permitted by copyright law.
 
 A copyright notice is included at the end of each document to affirm these terms.
+
+---
 
 ### Contributions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # The Dominion Covenant
 
+## Dedication
+
+This work is dedicated to the glory of God. The human author acts as a humble steward, holding the legal copyright in trust for the sole purpose of preserving the integrity of the work and ensuring it remains true to its foundational principles. All credit for any wisdom, coherence, or truth found herein belongs to Him alone.
+
+*Soli Deo Gloria*
+
+---
+
 ## Introduction
 
 The Dominion Covenant is a comprehensive, first-principles thought experiment in constitutional design. It represents a complete architectural blueprint for a potential future Canada, rebuilt from the ground up on a foundation of enduring moral principles, limited government, and robust individual liberty.


### PR DESCRIPTION
### Summary

This PR adds a formal "Dedication" section to the `LICENSE.md` and `README.md` files.

### Rationale

The purpose of this addition is to formally state the project's guiding philosophy of stewardship. It clarifies that while the author holds the legal copyright for the necessary purpose of protecting the work's integrity, the project itself is dedicated to the glory of God. This aligns the project's legal notices with its core theological principles as outlined in the Memorandums.

### Changes Made

- Added a `### Dedication` section to the top of `LICENSE.md`.
- Added a `### Dedication` section to the top of `README.md`.