### PR TITLE
docs(government): Add preamble of delegated authority

### DIFF
--- a/charters/02. The Constitution of Government.md
+++ b/charters/02. The Constitution of Government.md
@@ -2,6 +2,12 @@
 
 ---
 
+### PREAMBLE OF DELEGATED AUTHORITY
+
+> Acknowledging that all just authority is delegated by God, who alone is sovereign, this Constitution establishes the framework for a government that is His servant (*diakonos*). Its powers are therefore not inherent, but are a sacred and limited trust, to be exercised in humble accountability to Him and in strict submission to the **Charter of Immutable Principles**.
+
+---
+
 ### PREAMBLE
 This document establishes the structure, powers, and procedures of the government of Canada. It is the highest operational law of the land and is subordinate only to the **Charter of Immutable Principles**. All articles herein must be interpreted in a manner consistent with the **Charter**.
 


### PR DESCRIPTION
### Summary

This PR adds a "Preamble of Delegated Authority" to the top of `02. The Constitution of Government.md`.

### Rationale

This change makes the foundational principle of the state's delegated authority and its accountability to God explicit within the charter that defines the government's structure. By placing this statement at the very beginning, it ensures that the entire document is read through the lens of a limited, divinely-delegated trust, reinforcing a core tenet of the project's philosophy.

### Changes Made

-   Added a new `### PREAMBLE OF DELEGATED AUTHORITY` block to `charters/02. The Constitution of Government.md`.
