### PR TITLE
feat(principles): Add Article 12 on citizenship and residency

### DIFF
--- a/charters/01. THE CORE IMMUTABLE PRINCIPLES OF THE CONSTITUTION OF CANADA.md
+++ b/charters/01. THE CORE IMMUTABLE PRINCIPLES OF THE CONSTITUTION OF CANADA.md
@@ -356,7 +356,25 @@ In all criminal prosecutions, the accused shall enjoy the following, non-negotia
 
 ---
 
-### ARTICLE 12: NATIONAL SOVEREIGNTY
+### ARTICLE 12: THE DOCTRINE OF COVENANTAL CITIZENSHIP AND LAWFUL RESIDENCY
+
+1.  **Preamble of Principle:** This nation is a covenantal body politic, a union of citizens who voluntarily bind themselves in allegiance to this Charter. This Article defines the distinction between a member of this covenant (a Citizen) and a welcomed guest living under its protection (a Lawful Resident).
+
+2.  **The Status of the Citizen:** A Citizen is a full member of the national covenant. Citizenship is the sole and exclusive prerequisite for the exercise of political power. The core political rights reserved exclusively for Citizens are: (a) The right to vote; (b) The right to hold any public or elected office; (c) The right and duty of service in the Regulated Militia.
+
+3.  **The Status of the Lawful Resident:** A Lawful Resident is a non-citizen who resides within the nation by its express permission. They are esteemed guests, not members of the covenantal family.
+
+4.  **The Principle of One Law for Civil Justice:** In all matters of civil and criminal justice, there shall be one law for the Citizen and the Lawful Resident alike. Every Lawful Resident shall be afforded the full protection of this Charter concerning the rights to life, property, security from unreasonable search, and a fair and public trial.
+
+5.  **The Sphere of Conscience for the Resident:** Every Lawful Resident is guaranteed the freedom of private conscience. They shall not be compelled by the state to affirm any creed or participate in any religious observance. They may peacefully worship in their own homes and private institutions and teach their own faith without state interference.
+
+6.  **The Limit on Public Agitation:** The freedom of speech granted to a Lawful Resident does not extend to public political agitation that has as its primary purpose the subversion of the Core Immutable Principles of this Charter.
+
+7.  **The Path to Citizenship:** The sole path by which a Lawful Resident may become a Citizen is through a formal process of naturalization, culminating in the swearing of a binding, public Oath of Allegiance to this Charter.
+
+---
+
+### ARTICLE 13: NATIONAL SOVEREIGNTY
 
 1.  Canada is a sovereign and independent nation. The ultimate authority for all governance resides exclusively with the people of Canada through this Charter and the Constitution of Government. No law or directive originating from a foreign power, international body, private foundation, or non-governmental organization shall have legal force within the nation, unless it is explicitly and lawfully adopted through the nation's own legislative process.
 
@@ -368,7 +386,7 @@ In all criminal prosecutions, the accused shall enjoy the following, non-negotia
 
 ---
 
-### ARTICLE 13: THE GREAT WRIT OF HABEAS CORPUS
+### ARTICLE 14: THE GREAT WRIT OF HABEAS CORPUS
 
 ---
 


### PR DESCRIPTION
### Summary

This PR makes a foundational addition to `01. THE CORE IMMUTABLE PRINCIPLES OF THE CONSTITUTION OF CANADA.md` by inserting a new **Article 12: The Doctrine of Covenantal Citizenship and Lawful Residency**. All subsequent articles (National Sovereignty and Habeas Corpus) have been renumbered accordingly to Articles 13 and 14.

### Problem Addressed

A long-term structural analysis identified a critical vulnerability in the Dominion Covenant framework: the **"Problem of Pluralism."** The project lacked a defined, constitutional mechanism for managing the inevitable presence of a diverse, non-covenantal population over the long term. This ambiguity created a risk of either societal dilution, where the core identity of the nation is lost, or the creation of an unstable and unjust system for non-adherents.

### Solution Implemented

This new Article 12 directly addresses this vulnerability by codifying a modern **"Sojourner Framework"** into the immutable foundation of the nation. It creates two distinct and legally defined classes:

1.  **Citizen (Covenant Member):** The full members of the body politic who possess all political rights and duties.
2.  **Lawful Resident (Sojourner):** Esteemed guests who are afforded full protection under civil and criminal law and freedom of private conscience, but do not possess political rights.

The article establishes the "One Law" principle for justice while clearly defining the limits of a Lawful Resident's public political action, thereby protecting the core identity of the covenantal state. It also affirms a clear path for a Lawful Resident to become a Citizen through a formal oath of allegiance.

This change is not a minor policy addition; it is a critical piece of constitutional architecture designed to ensure the long-term stability and cohesion of the Dominion Covenant in a complex world.