### PR TITLE
docs(project): Add memorandum on the philosophy of suffrage

### DIFF
--- a/docs/Memorandum on the Right of Suffrage.md
+++ b/docs/Memorandum on the Right of Suffrage.md
@@ -1,0 +1,83 @@
+# Memorandum on the Right of Suffrage: A Restoration of Stewardship
+
+---
+
+### PREAMBLE
+
+Of all the principles upon which the Dominion Covenant is built, none stands in starker contrast to the spirit of the modern age than its doctrine of suffrage. The contemporary West holds as its most sacred and unquestioned dogma the belief in universal, autonomy-based suffrage—the idea that the right to vote is an inherent and unconditional right of every individual adult.
+
+This memorandum will argue that this modern assumption is a profound and catastrophic error, born of the same **Genesis 3:5 Principle** that animates the secular state. It will demonstrate that a system of universal suffrage, detached from any corresponding duty or earned stake in the nation, is not a guarantor of liberty but an engine of its decay.
+
+Finally, it will provide the definitive philosophical and theological defense for the Covenant's alternative: a model of **Covenantal Suffrage**, wherein the vote is not a right of individual autonomy, but a sacred duty of stewardship, rooted in the consistent pattern of governance revealed in the Holy Bible, and earned by those who have made a tangible, costly, and public commitment to the future of the nation.
+
+---
+
+### I. The Foundational Error of Universal Suffrage: The Sovereignty of the Self
+
+The doctrine of universal suffrage is the political expression of a theological claim: the sovereignty of the individual will. It declares that the mere fact of one's existence and presence within a territory grants one the right to exercise power over the governance of that territory. This creates a political order founded not on wisdom, duty, or stewardship, but on the aggregated, unqualified desires of the populace.
+
+A political system founded on this principle inevitably bears corrupt fruit:
+
+*   **The Devaluation of the Vote:** When a right is granted to all without condition, it becomes cheap. It is transformed from a solemn responsibility into a low-cost consumer choice, often exercised with little more thought than the selection of a product from a shelf.
+*   **The Rise of the Demagogue:** A system governed by the uninformed and uninvested is a fertile ground for the demagogue, who learns that the path to power is not through appeals to reason and virtue, but through the promising of state-provided benefits and the stoking of envy and division.
+*   **The Tyranny of the Present:** An electorate with no tangible "skin in the game" will reliably vote for its own immediate gratification at the expense of the future. It will demand more services than it is willing to pay for, sanctioning the accumulation of ruinous public debt that is passed on to the next generation. It is a system that eats its own seed corn.
+*   **The Erosion of the Citizen:** The model of universal suffrage creates subjects and dependents, not citizens. It fosters a mindset of "what is the state's duty to me?" rather than "what is my duty to the state?"
+
+The pre-covenantal collapse—the "Year Zero" premise of this entire project—is the logical and inevitable endpoint of a society founded on this flawed doctrine.
+
+---
+
+### II. The Biblical Pattern of Steward-Leadership
+
+The Dominion Covenant does not invent its model of suffrage from whole cloth. It is a deliberate restoration of the principles of governance consistently modeled throughout Scripture. The biblical pattern is not one of individual autonomy, but of **covenantal headship and qualified stewardship**.
+
+*   **The Household as the Foundational Unit:** From Genesis to the New Testament, the fundamental unit of society is not the autonomous individual, but the family or household. In the Old Covenant, political and social representation was exercised through the heads of households, the elders of the tribes, and the leaders of families (Exodus 18:21, Deuteronomy 1:13). The nation was a federation of covenantal households, not a mass of disconnected individuals.
+*   **Leadership Based on Proven Stewardship:** The New Testament reinforces this principle in its qualifications for leadership within the Church. An elder must be one who "manages his own household well" (1 Timothy 3:4-5). This establishes a profound biblical principle: **fitness for public responsibility is demonstrated by faithfulness in private, domestic responsibility.** The home is the proving ground for the steward.
+*   **The Parable of the Talents:** Christ's teaching in the Parable of the Talents (Matthew 25:14-30) provides the ultimate theological metaphor for the Covenant's doctrine. The Master (God) entrusts his property (the nation and its governance) to his servants (the citizens). He does not give equally to all, but according to their ability. Upon his return, he grants greater authority *only* to those who have been faithful stewards of what they were given. The unfaithful servant who buried his talent has it taken away. The vote, therefore, is not a "talent" given to all unconditionally; it is the *reward* of greater responsibility given to the faithful steward.
+
+The Covenant's model of suffrage is the direct application of this consistent biblical witness. It rejects the modern, individualistic model and restores the household as a cornerstone of the political order, while making proven stewardship the prerequisite for exercising authority.
+
+---
+
+### III. The Covenant's Solution: Suffrage as an Earned Office of Stewardship
+
+The Dominion Covenant restores the vote to its proper place as a **duty of stewardship**. The right to vote is not an inherent right of personhood; it is the earned right of a **Citizen-Steward**.
+
+Under the Covenant, this proof of stewardship is not a matter of wealth, education, or social status. It is a matter of **costly, public, and covenantal commitment.** The question is not "Are you here?" but "Have you bound yourself to the fate of this nation and its posterity in a manner that reflects the biblical pattern of responsibility?"
+
+---
+
+### IV. The Two Pillars of Stewardship: The Guardian and the Homemaker
+
+The state recognizes the complementary vocations of men and women, and the structure of earned suffrage is the highest political expression of this truth. The two paths to becoming an Elector correspond to the two foundational forms of stewardship necessary for a nation's survival, each reflecting a part of the biblical pattern: its **defense** and its **perpetuation**.
+
+**1. The Male Vocation: The Guardian**
+A man's path to the ballot box is through the crucible of **National Service**. This reflects the Old Testament muster of able-bodied men for the common defense and is his rite of passage from the private world of self-interest to the public world of civic responsibility.
+
+*   **The Costly Commitment:** By serving in the Regulated Militia or the National Service Corps, he makes a tangible investment of his time, his labor, and his willingness to risk his life for the physical security of the nation.
+*   **The Earned Stake:** A man who has served is no longer a mere resident; he is a **Guardian**. He has a permanent and undeniable stake in the peace, order, and liberty he was trained to defend. His vote is therefore not a mere opinion; it is the considered counsel of a shareholder in the nation's security. This is the sole and exclusive path by which a man earns his vote.
+
+**2. The Female Vocation: The Steward of the Household**
+A woman's path to the ballot box is through her entry into the **covenant of Marriage**. This act reflects the biblical principle that the household is the bedrock of society and that its faithful management is the prerequisite for public trust.
+
+*   **The Costly Commitment:** The covenant of Marriage is a lifelong vow to build and steward a **household**. It is a public commitment to stability, fidelity, and the creation of a sanctuary for the next generation, reflecting the very duties praised in the New Testament household codes (Ephesians 5, Titus 2).
+*   **The Earned Stake:** A woman who enters this covenant becomes a **Steward of the Household**. Her investment is not in the nation's immediate physical defense, but in its long-term future and moral character. She is the primary guardian of the nation's posterity. Her vote is therefore the considered counsel of one who has proven her fitness for public trust by her commitment to the foundational private institution, embodying the 1 Timothy 3 principle.
+
+---
+
+### V. The Fruits of Covenantal Suffrage
+
+A system that reserves the vote for proven stewards will produce a radically different and healthier body politic.
+
+*   **An Electorate of Stakeholders:** The act of voting is conducted by a cohort of citizens who have all made a significant, personal sacrifice for the nation's well-being.
+*   **A Future-Oriented Polity:** The electorate is composed exclusively of those who have either physically defended the nation or have formally committed to building its next generation.
+*   **The Restoration of Political Seriousness:** When the vote is a hard-won duty, it is treated with the gravity it deserves.
+*   **A Natural Check on State Power:** An electorate of Guardians and Household Stewards is instinctively skeptical of state overreach, resistant to the siren song of dependency, and fiercely protective of the family's sovereignty.
+
+---
+
+### VI. Conclusion: A Republic of Faithful Stewards
+
+The Dominion Covenant's model of suffrage is not an exclusion; it is an elevation. It is not intended to disenfranchise, but to re-enfranchise the very concept of a meaningful vote. It is the architectural solution to the fatal flaws of a mass democracy built on the sand of individual autonomy.
+
+By tying the exercise of political power to the performance of covenantal duty, as modeled in the patterns of Scripture, the Covenant seeks to create what the modern world has lost: a true republic of faithful stewards. It is a framework designed for a people who understand that liberty is not the freedom to do what one wants, but the disciplined freedom to do what one ought, and that the right to govern is a trust from God that must be earned.


### PR DESCRIPTION
**Description**

This pull request adds the new `Memorandum on the Right of Suffrage: A Restoration of Stewardship` to the `/docs` directory.

This essential document provides the complete theological and philosophical justification for the project's model of "Covenantal Suffrage." It addresses one of the most foundational and distinct aspects of the Dominion Covenant, explaining why the right to vote is framed as an earned office of stewardship rather than an inherent right of autonomy.

The memorandum:
-   Critiques the modern doctrine of universal suffrage from a first-principles perspective.
-   Grounds the Covenant's model in biblical patterns of household governance and demonstrated responsibility (e.g., 1 Timothy 3, Exodus 18).
-   Articulates the rationale for the two distinct paths to earning suffrage for men (National Service) and women (Marriage) as complementary forms of covenantal commitment.

This addition helps to ensure that the "why" behind the "what" of Article 15 of the Core Immutable Principles is clearly and robustly documented, consistent with the project's goal of philosophical coherence.